### PR TITLE
Bump ffi-napi and ref-napi versions

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "swift-search",
-  "version": "2.0.2",
+  "version": "2.0.4",
   "description": "Swift Search is a Javascript binding for search library which is written in C (Apache Lucene)",
   "main": "lib/index.js",
   "types": "lib/index.d.ts",
@@ -23,11 +23,9 @@
   },
   "homepage": "https://github.com/symphonyoss/SwiftSearch#readme",
   "devDependencies": {
-    "@types/ffi-napi": "2.4.1",
     "@types/jest": "23.3.0",
     "@types/keymirror": "0.1.1",
     "@types/node": "10.5.2",
-    "@types/ref-napi": "1.4.0",
     "browserify": "16.2.2",
     "cross-env": "5.2.0",
     "electron": "9.4.1",
@@ -40,8 +38,8 @@
   "dependencies": {
     "diskusage": "1.1.3",
     "electron-log": "2.2.16",
-    "ffi-napi": "2.4.5",
+    "ffi-napi": "^4.0.3",
     "keymirror": "0.1.1",
-    "ref-napi": "1.4.1"
+    "ref-napi": "^3.0.3"
   }
 }


### PR DESCRIPTION
## Description
- Bump `ffi-napi` and `ref-napi` versions
- Bump `Swift-Search` version to 2.0.4